### PR TITLE
print the correct missing file when datasets is messed up

### DIFF
--- a/xpctl/cli.py
+++ b/xpctl/cli.py
@@ -234,7 +234,7 @@ def delete(task, eid):
 @click.argument('dataset')
 def putresult(task, config, log, dataset, user, label, cbase, cstore):
     """
-    Puts the results in a database. provide task name, config file, the reporting log file, and the dataset file
+    Puts the results in a database. provide task name, config file, the reporting log file, and the dataset index file
     used in the experiment. Optionally can put the model files in a persistent storage.
     """
     logf = log.format(task)
@@ -245,7 +245,7 @@ def putresult(task, config, log, dataset, user, label, cbase, cstore):
         click.echo(click.style("the config file at {} doesn't exist, provide a valid location".format(config), fg='red'))
         return
     if not os.path.exists(dataset):
-        click.echo(click.style("the dataset file at {} doesn't exist, provide a valid location".format(config), fg='red'))
+        click.echo(click.style("the dataset file at {} doesn't exist, provide a valid location".format(dataset), fg='red'))
         return
     config_obj = read_config_file(config)
     datasets_set = index_by_label(read_config_file(dataset))


### PR DESCRIPTION
This PR updates the error message for the putresult command so that the correct argument (that is wrong) shows up in the message.

It also updates the help to make the fact that the dataset argument is the dataset index file (rather than then name of the dataset) more explicit.

As a side note it is annoying that click doesn't let us put help messages on positional arguments.