### PR TITLE
Fix/multiple datasets

### DIFF
--- a/xpctl/backends/backend.py
+++ b/xpctl/backends/backend.py
@@ -193,7 +193,7 @@ class ExperimentGroup(object):
                 for experiment in _experiments:
                     results = experiment.get_prop(event_type)
                     for result in results:
-                        if result.metric not in data[reduction_dim_value]:
+                        if result.metric not in data[reduction_dim_value][dataset]:
                             data[reduction_dim_value][dataset][result.metric] = [result.value]
                         else:
                             data[reduction_dim_value][dataset][result.metric].append(result.value)
@@ -233,6 +233,7 @@ class ExperimentGroup(object):
                     for metric in data[reduction_dim_value][dataset]:
                         for fn_name, fn in aggregate_fns.items():
                             agg_value = fn(data[reduction_dim_value][dataset][metric])
+                            print(metric, dataset, fn_name, data[reduction_dim_value][dataset][metric], agg_value)
                             values[fn_name] = agg_value
                         agr.add_result(deepcopy(AggregateResult(metric=metric, values=values)), event_type=event_type)
                     aggregate_resultset.add_data(agr)


### PR DESCRIPTION
Previously, the aggregation for results was done along only one dimension (which typically is `sha1`), which would give you a list of datasets when you use the typical dataset strategy in baseline. This PR makes an additional aggregation along the dataset dimension. 

IOW, previously,

```
xpctl results taskname dataset_name
 
                                           dataset                                      sha1 num_exps       acc     
                                                                                                              avg  std
0  ['dataset_name:date_1', 'dataset_name:date_2'  xyz       1  0.514655  0.0
0  ['dataset_name:date_2', 'dataset_name:date_2'  abc      1  0.511551  0.0
```

Now,

```
xpctl results taskname dataset_name
 
                                           dataset                                      sha1 num_exps       acc     
                                                                                                              avg  std
0  'dataset_name:date_1'  xyz       1  0.514655  0.0
0  'dataset_name:date_1'   abc      1  0.511551  0.0
```


Also, the tests were failing on master and this PR corrects that.

To test, run the server in `${XPCTL_HOME}/xpctl` with  `python -m xpserver --cred xpctlcred.json` and test the client by `xpctl --host localhost:5310/v2 results task_name dataset_name`
