### PR TITLE
feat: Allow for redirection of config2json output

### DIFF
--- a/xpctl/cli.py
+++ b/xpctl/cli.py
@@ -38,9 +38,9 @@ class ServerManager(object):
         if ServerManager.api is not None:
             click.echo(click.style(
                 "connection with xpctl server successful with [host]: {}".format(ServerManager.host), fg='green'
-            ))
+            ), err=True)
             return ServerManager.api
-        click.echo(click.style("server connection unsuccessful, aborting", fg='red'))
+        click.echo(click.style("server connection unsuccessful, aborting", fg='red'), err=True)
         sys.exit(1)
 
 
@@ -168,13 +168,17 @@ def details(task, sha1, user, metric, sort, event_type, n, output, output_fields
 @cli.command()
 @click.argument('task')
 @click.argument('sha1')
-@click.argument('filename')
-def config2json(task, sha1, filename):
+@click.argument('filename', required=False)
+@click.option("--indent", help="The number of spaces to indent the json output", type=int, default=2)
+def config2json(task, sha1, filename, indent=2):
     """Exports the config file for an experiment as a json file."""
     ServerManager.get()
     try:
         result = ServerManager.api.config2json(task, sha1)
-        write_config_file(result, filename)
+        if filename is not None:
+            write_config_file(result, filename)
+        else:
+            click.echo(json.dumps(result, indent=indent))
     except ApiException as e:
         click.echo(click.style(json.loads(e.body)['detail'], fg='red'))
 


### PR DESCRIPTION
Currently in xpctl the `config2json` command requires a `filename` argument for where to save the resulting configuration.
This means that in order to examine/query the output config in the terminal we need to do something like
`xpctl config2json ${TASK} ${SHA1} /tmp/a.json && cat /cat/a.json | jq` Given that this is one of the most common things I
do with xpctl (checking what the config is for some results) it was very annoying to do each time.

This PR updates the `config2json` command to be more unix like and allow for output redirection. The `filename` is now
an optional argument, when it is given it the code will work the exact same. When the file name is not given the it echo
the the result to the screen so that we can do things like redirection to a file or pipe it into something like `jq`.

It also updates some of the logging so it goes to `stderr` instead of `stdout` which was breaking the redirection.

_note_ unlike a normal unix tool when output the json result we don't output it as a single line. This could be weird but it
given the `click` integration I don't know how easy it is to detect if the output is the terminal (were we would print indented
json) and then we are redirected (and would output a single line). There is also a question of if we should do different
behavior on if it is a file or a pipe (indent the first, single line the latter) and if this is detectable.